### PR TITLE
fix: docker-compose wrong postgres + admin redirection ports

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,11 +83,11 @@ services:
       POSTGRES_USER: cqdg
       POSTGRES_PASSWORD: password
     ports:
-      - 5532:5432
+      - 5432:5432
   cqdg-data-submission-adminer:
     image: adminer
     ports:
-      - 5180:8080
+      - 8080:8080
   cqdg-data-submission-minio:
     image: minio/minio
     environment:


### PR DESCRIPTION
Maybe there is a reason why it's like this, TBC.